### PR TITLE
Add simple agent API

### DIFF
--- a/src/handlers/agent.rs
+++ b/src/handlers/agent.rs
@@ -1,0 +1,39 @@
+use crate::models::agent::{Agent, NewAgent, UpdateAgent};
+use crate::services::agent_service::AgentService;
+use actix_web::{web, HttpResponse, Responder};
+use uuid::Uuid;
+
+pub async fn create_agent(new_agent: web::Json<NewAgent>) -> impl Responder {
+    let agent = AgentService::create_agent(new_agent.into_inner());
+    HttpResponse::Created().json(agent)
+}
+
+pub async fn list_agents() -> impl Responder {
+    let agents = AgentService::list_agents();
+    HttpResponse::Ok().json(agents)
+}
+
+pub async fn get_agent(path: web::Path<Uuid>) -> impl Responder {
+    match AgentService::get_agent(path.into_inner()) {
+        Some(agent) => HttpResponse::Ok().json(agent),
+        None => HttpResponse::NotFound().finish(),
+    }
+}
+
+pub async fn update_agent(
+    path: web::Path<Uuid>,
+    update: web::Json<UpdateAgent>,
+) -> impl Responder {
+    match AgentService::update_agent(path.into_inner(), update.into_inner()) {
+        Some(agent) => HttpResponse::Ok().json(agent),
+        None => HttpResponse::NotFound().finish(),
+    }
+}
+
+pub async fn delete_agent(path: web::Path<Uuid>) -> impl Responder {
+    if AgentService::delete_agent(path.into_inner()) {
+        HttpResponse::NoContent().finish()
+    } else {
+        HttpResponse::NotFound().finish()
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -18,6 +18,7 @@ pub mod temp_image;
 pub mod user;
 pub mod user_llm_config;
 pub mod worker;
+pub mod agent;
 
 // Re-export all the modules through the chat module
 pub use self::chat::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,11 @@ mod routes;
 mod schema;
 mod services;
 mod utils;
+
 use dotenv::dotenv;
 
 use actix_cors::Cors;
-use actix_web::{middleware, web, App, Error, HttpResponse, HttpServer};
+use actix_web::{middleware, web, App, Error, HttpServer};
 use log::debug;
 
 use db::{create_db_pool, setup_database};
@@ -28,6 +29,7 @@ fn query_error_handler(
 ) -> Error {
     actix_web::error::ErrorBadRequest(err)
 }
+
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {

--- a/src/models/agent.rs
+++ b/src/models/agent.rs
@@ -1,0 +1,24 @@
+use serde::{Serialize, Deserialize};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Agent {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Deserialize)]
+pub struct NewAgent {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateAgent {
+    pub name: Option<String>,
+    pub description: Option<String>,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -9,6 +9,7 @@ pub mod pipeline;
 pub mod secure_vault;
 pub mod user;
 pub mod worker;
+pub mod agent;
 
 // New chat-related models
 pub mod attachment;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -8,7 +8,7 @@ use crate::handlers::llm_provider::{
     update_user_llm_config,
 };
 use crate::handlers::{
-    amber_store, api_key, attachment, configuration, docker_file, fluentcli, job, llm, pipeline,
+    amber_store, api_key, agent, attachment, configuration, docker_file, fluentcli, job, llm, pipeline,
     secure_vault, stream_chat, temp_image, user, worker,
 };
 use crate::utils::auth::Auth;
@@ -155,6 +155,14 @@ pub fn configure_routes() -> Scope {
                     "/user-configs/{id}",
                     web::delete().to(delete_user_llm_config),
                 ),
+        )
+        .service(
+            web::scope("/agents")
+                .route("", web::post().to(agent::create_agent))
+                .route("", web::get().to(agent::list_agents))
+                .route("/{id}", web::get().to(agent::get_agent))
+                .route("/{id}", web::put().to(agent::update_agent))
+                .route("/{id}", web::delete().to(agent::delete_agent)),
         )
         .service(temp_image::get_temp_image)
 }

--- a/src/services/agent_service.rs
+++ b/src/services/agent_service.rs
@@ -1,0 +1,57 @@
+use crate::models::agent::{Agent, NewAgent, UpdateAgent};
+use chrono::Utc;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use lazy_static::lazy_static;
+use uuid::Uuid;
+
+lazy_static! {
+    static ref AGENTS: Mutex<HashMap<Uuid, Agent>> = Mutex::new(HashMap::new());
+}
+
+pub struct AgentService;
+
+impl AgentService {
+    pub fn create_agent(new_agent: NewAgent) -> Agent {
+        let agent = Agent {
+            id: Uuid::new_v4(),
+            name: new_agent.name,
+            description: new_agent.description,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let mut map = AGENTS.lock().unwrap();
+        map.insert(agent.id, agent.clone());
+        agent
+    }
+
+    pub fn list_agents() -> Vec<Agent> {
+        let map = AGENTS.lock().unwrap();
+        map.values().cloned().collect()
+    }
+
+    pub fn get_agent(id: Uuid) -> Option<Agent> {
+        let map = AGENTS.lock().unwrap();
+        map.get(&id).cloned()
+    }
+
+    pub fn update_agent(id: Uuid, update: UpdateAgent) -> Option<Agent> {
+        let mut map = AGENTS.lock().unwrap();
+        if let Some(entry) = map.get_mut(&id) {
+            if let Some(name) = update.name {
+                entry.name = name;
+            }
+            if let Some(desc) = update.description {
+                entry.description = Some(desc);
+            }
+            entry.updated_at = Utc::now();
+            return Some(entry.clone());
+        }
+        None
+    }
+
+    pub fn delete_agent(id: Uuid) -> bool {
+        let mut map = AGENTS.lock().unwrap();
+        map.remove(&id).is_some()
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -14,6 +14,7 @@ pub mod pipeline_service;
 pub mod secure_vault_service;
 pub mod user_service;
 pub mod worker_service;
+pub mod agent_service;
 
 pub use amber_store_service::AmberStoreService;
 pub use api_key_service::ApiKeyService;
@@ -31,3 +32,4 @@ pub use pipeline_service::PipelineService;
 pub use secure_vault_service::SecureVaultService;
 pub use user_service::UserService;
 pub use worker_service::WorkerService;
+pub use agent_service::AgentService;


### PR DESCRIPTION
## Summary
- add new Agent model
- add AgentService storing agents in-memory
- implement Agent HTTP handlers and routes

## Testing
- `cargo check --locked --offline` *(fails: no matching package named `actix-web` found)*
- `./run_tests.sh` *(fails: server not running)*