### PR TITLE
Refine LLM service logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,5 @@ pub mod services;
 pub mod utils;
 
 #[cfg(test)]
-
-mod tests {
-    pub mod chat_service_tests;
-    pub mod metrics_tests;
-}
-
 mod tests;
 


### PR DESCRIPTION
## Summary
- connect `LLMService::chat` to provider trait implementations
- remove unused helper functions
- fix test module configuration in `lib.rs`

## Testing
- `cargo test` *(fails: could not fetch crates)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the test module structure for easier maintenance.
  - Centralized provider-specific logic for request preparation and response parsing, improving code organization and maintainability.

- **Chores**
  - Removed redundant internal methods and streamlined delegation to provider implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->